### PR TITLE
Handle replica flex servers first

### DIFF
--- a/.github/workflows/flexibleserver-auto-start.yaml
+++ b/.github/workflows/flexibleserver-auto-start.yaml
@@ -2,7 +2,7 @@ name: flexible-server-auto-start
 on:
   workflow_dispatch:
   schedule:
-    - cron: "30 6 * * 1-5" # Every weekday at 6:30am BST
+    - cron: '30 6 * * 1-5' # Every weekday at 6:30am BST
 env:
   DEV_ENV: ${{ secrets.DEV_ENV }}
 permissions:
@@ -13,12 +13,47 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: "Az CLI login"
+      - name: 'Az CLI login'
         uses: azure/login@v2
         with:
           client-id: 2b6fa9d7-7dba-4600-a58a-5e25554997aa # DTS AKS Auto-Shutdown
           tenant-id: 531ff96d-0ae9-462a-8d2d-bec7c0b42082 # HMCTS.NET
           allow-no-subscriptions: true
+
+      - name: Staging Replicas - Postgres Flexible server Auto Start
+        run: ./scripts/flexible-server/auto-start-stop.sh start staging replicas
+        env:
+          DEV_ENV: ${{ env.DEV_ENV }}
+
+      - name: Test Replicas - Postgres Flexible server Auto Start
+        run: ./scripts/flexible-server/auto-start-stop.sh start testing replicas
+        env:
+          DEV_ENV: ${{ env.DEV_ENV }}
+
+      - name: Demo Replicas - Postgres Flexible server Auto Start
+        run: ./scripts/flexible-server/auto-start-stop.sh start demo replicas
+        env:
+          DEV_ENV: ${{ env.DEV_ENV }}
+
+      - name: Development Replicas - Postgres Flexible server Auto Start
+        run: ./scripts/flexible-server/auto-start-stop.sh start development replicas
+        env:
+          DEV_ENV: ${{ env.DEV_ENV }}
+
+      - name: Sandbox Replicas - Postgres Flexible server Auto Start
+        run: ./scripts/flexible-server/auto-start-stop.sh start sandbox replicas
+        env:
+          DEV_ENV: ${{ env.DEV_ENV }}
+
+      - name: ITHC Replicas - Postgres Flexible server Auto Start
+        run: ./scripts/flexible-server/auto-start-stop.sh start ithc replicas
+        env:
+          DEV_ENV: ${{ env.DEV_ENV }}
+
+      - name: Untagged Replicas - Postgres Flexible server Auto Start
+        run: ./scripts/flexible-server/auto-start-stop.sh start untagged replicas
+        env:
+          DEV_ENV: ${{ env.DEV_ENV }}
 
       - name: Staging - Postgres Flexible server Auto Start
         run: ./scripts/flexible-server/auto-start-stop.sh start staging

--- a/scripts/flexible-server/common-functions.sh
+++ b/scripts/flexible-server/common-functions.sh
@@ -19,12 +19,19 @@ function get_flexible_sql_servers() {
     area_selector="| where tags.businessArea == '$2'"
   fi
 
+  if [ -z $3 ]; then
+    replica_selector="| where id !contains 'replica'"
+  else
+    replica_selector="| where id contains 'replica'"
+  fi
+
   az graph query -q "
     resources
     | where type =~ 'microsoft.dbforpostgresql/flexibleservers'
     | where tags.autoShutdown == 'true'
     $env_selector
     $area_selector
+    $replica_selector
     | project name, resourceGroup, subscriptionId, ['tags'], properties.state, ['id']
     " --first 1000 -o json
 


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
https://tools.hmcts.net/jira/browse/DTSPO-22851

### Change description
- Logic was added previously to start replica servers first - https://github.com/hmcts/auto-shutdown/pull/738/files 
- This was not re-implemented after the move to `az-graph`
- Updates the `get_flexible_sql_servers` function to retrieve replicas only based on an argument
- Adds new steps to start the replica flex servers in each environment before the others
<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
